### PR TITLE
Update bindings for ctypes-0.6 compatibility.

### DIFF
--- a/src/lib_gen/cephes_bindgen.ml
+++ b/src/lib_gen/cephes_bindgen.ml
@@ -4,9 +4,13 @@ module Invert (B: Cstubs.BINDINGS) (I: Cstubs_inverted.INTERNAL) =
   struct
     module Ignored =
       B(struct
-        type 'a fn = unit
+        type 'a fn = 'a Ctypes.fn
+        type _ result = unit
+        type 'a return = 'a
         let foreign name fn = I.internal name fn (fun _ -> assert false)
         let foreign_value _ = failwith "foreign_value not supported"
+        let returning = Ctypes.returning
+        let (@->) = Ctypes.(@->)
       end)
   end
 

--- a/src/lib_gen/cephes_bindings.ml
+++ b/src/lib_gen/cephes_bindings.ml
@@ -3,69 +3,69 @@ open Ctypes
 module C(F: Cstubs.FOREIGN) = struct
 
   (* bdtr.c *)
-  let bdtr      = F.foreign "bdtr"    (int @-> int @-> double @-> returning double)
-  let bdtrc     = F.foreign "bdtrc"   (int @-> int @-> double @-> returning double)
-  let bdtri     = F.foreign "bdtri"   (int @-> int @-> double @-> returning double)
+  let bdtr      = F.(foreign "bdtr"    (int @-> int @-> double @-> returning double))
+  let bdtrc     = F.(foreign "bdtrc"   (int @-> int @-> double @-> returning double))
+  let bdtri     = F.(foreign "bdtri"   (int @-> int @-> double @-> returning double))
 
   (* btdtr.c *)
-  let btdtr     = F.foreign "btdtr"   (double @-> double @-> double @-> returning double)
+  let btdtr     = F.(foreign "btdtr"   (double @-> double @-> double @-> returning double))
 
   (* chbevl.c *)
-  let chbevl    = F.foreign "chbevl"  (double @-> ptr double @-> int @-> returning double)
+  let chbevl    = F.(foreign "chbevl"  (double @-> ptr double @-> int @-> returning double))
 
   (* chdtr.c *)
-  let chdtr     = F.foreign "chdtr"   (double @-> double @-> returning double)
-  let chdtrc    = F.foreign "chdtrc"  (double @-> double @-> returning double)
-  let chdtri    = F.foreign "chdtri"  (double @-> double @-> returning double)
+  let chdtr     = F.(foreign "chdtr"   (double @-> double @-> returning double))
+  let chdtrc    = F.(foreign "chdtrc"  (double @-> double @-> returning double))
+  let chdtri    = F.(foreign "chdtri"  (double @-> double @-> returning double))
 
   (* expx2.c *)
-  let expx2     = F.foreign "expx2"   (double @-> int @-> returning double)
+  let expx2     = F.(foreign "expx2"   (double @-> int @-> returning double))
 
   (* fdtr.c *)
-  let fdtr      = F.foreign "fdtr"    (int @-> int @-> double @-> returning double)
-  let fdtrc     = F.foreign "fdtrc"   (int @-> int @-> double @-> returning double)
-  let fdtri     = F.foreign "fdtri"   (int @-> int @-> double @-> returning double)
+  let fdtr      = F.(foreign "fdtr"    (int @-> int @-> double @-> returning double))
+  let fdtrc     = F.(foreign "fdtrc"   (int @-> int @-> double @-> returning double))
+  let fdtri     = F.(foreign "fdtri"   (int @-> int @-> double @-> returning double))
 
   (* gamma.c *)
-  let gamma     = F.foreign "gamma"   (double @-> returning double)
-  let lgam      = F.foreign "lgam"    (double @-> returning double)
+  let gamma     = F.(foreign "gamma"   (double @-> returning double))
+  let lgam      = F.(foreign "lgam"    (double @-> returning double))
 
   (* gdtr.c *)
-  let gdtr      = F.foreign "gdtr"    (double @-> double @-> double @-> returning double)
-  let gdtrc     = F.foreign "gdtrc"   (double @-> double @-> double @-> returning double)
+  let gdtr      = F.(foreign "gdtr"    (double @-> double @-> double @-> returning double))
+  let gdtrc     = F.(foreign "gdtrc"   (double @-> double @-> double @-> returning double))
 
   (* igam.c *)
-  let igam      = F.foreign "igam"    (double @-> double @-> returning double)
-  let igamc     = F.foreign "igamc"   (double @-> double @-> returning double)
+  let igam      = F.(foreign "igam"    (double @-> double @-> returning double))
+  let igamc     = F.(foreign "igamc"   (double @-> double @-> returning double))
 
   (* igami.c *)
-  let igami     = F.foreign "igami"   (double @-> double @-> returning double)
+  let igami     = F.(foreign "igami"   (double @-> double @-> returning double))
 
   (* incbet.c *)
-  let incbet    = F.foreign "incbet"  (double @-> double @-> double @-> returning double)
+  let incbet    = F.(foreign "incbet"  (double @-> double @-> double @-> returning double))
 
   (* incbi.c *)
-  let incbi     = F.foreign "incbi"   (double @-> double @-> double @-> returning double)
+  let incbi     = F.(foreign "incbi"   (double @-> double @-> double @-> returning double))
 
   (* nbdtr.c *)
-  let nbdtr     = F.foreign "nbdtr"   (int @-> int @-> double @-> returning double)
-  let nbdtrc    = F.foreign "nbdtrc"  (int @-> int @-> double @-> returning double)
-  let nbdtri    = F.foreign "nbdtri"  (int @-> int @-> double @-> returning double)
+  let nbdtr     = F.(foreign "nbdtr"   (int @-> int @-> double @-> returning double))
+  let nbdtrc    = F.(foreign "nbdtrc"  (int @-> int @-> double @-> returning double))
+  let nbdtri    = F.(foreign "nbdtri"  (int @-> int @-> double @-> returning double))
 
   (* ndtr.c *)
-  let ndtr      = F.foreign "ndtr"    (double @-> returning double)
-  let erf       = F.foreign "erf"     (double @-> returning double)
-  let erfc      = F.foreign "erfc"    (double @-> returning double)
+  let ndtr      = F.(foreign "ndtr"    (double @-> returning double))
+  let erf       = F.(foreign "erf"     (double @-> returning double))
+  let erfc      = F.(foreign "erfc"    (double @-> returning double))
 
   (* ndtri.c *)
-  let ndtri     = F.foreign "ndtri"   (double @-> returning double)
+  let ndtri     = F.(foreign "ndtri"   (double @-> returning double))
 
   (* pdtr.c *)
-  let pdtr      = F.foreign "pdtr"    (int @-> double @-> returning double)
-  let pdtrc     = F.foreign "pdtrc"   (int @-> double @-> returning double)
-  let pdtri     = F.foreign "pdtri"   (int @-> double @-> returning double)
+  let pdtr      = F.(foreign "pdtr"    (int @-> double @-> returning double))
+  let pdtrc     = F.(foreign "pdtrc"   (int @-> double @-> returning double))
+  let pdtri     = F.(foreign "pdtri"   (int @-> double @-> returning double))
 
   (* stdtr.c *)
-  let stdtr     = F.foreign "stdtr"   (int @-> double @-> returning double)
-  let stdtri    = F.foreign "stdtri"  (int @-> double @-> returning double)
+  let stdtr     = F.(foreign "stdtr"   (int @-> double @-> returning double))
+  let stdtri    = F.(foreign "stdtri"  (int @-> double @-> returning double))
 end


### PR DESCRIPTION
The next release of ctypes will include a small backwards-incompatible change to the `Cstubs` interface: `@->` and `returning` used in a bindings functor should now be imported from the functor argument, not from `Ctypes`.

See the following PR for more details: https://github.com/ocamllabs/ocaml-ctypes/pull/389

This pull request changes both the `Cephes_bindings` module and the stub generator to be compatible both with existing versions of ctypes and with the forthcoming 0.6 release.
